### PR TITLE
[Question1] モーダルを開いてもカウントが増えないの解消

### DIFF
--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -20,7 +20,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
   useEffect(() => {
     let countIgnore = false;
 
-    setInterval(() => {
+    let intervalId = setInterval(() => {
       if (!countIgnore) {
         setCount(count => count + 1);
       }
@@ -32,6 +32,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
 
     return () => {
       countIgnore = true;
+      clearInterval(intervalId);
     };
   }, [count, isOpen]);
 

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -24,6 +24,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
 
     if (!isOpen) {
       setCount(INITIAL_COUNT);
+      clearInterval(intervalId);
     }
 
     return () => {

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -15,7 +15,7 @@ import {
 const INITIAL_COUNT = 0; // タイマーの初期値
 
 function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
-  const [count, setCount] = useState(0);
+  const [count, setCount] = useState(INITIAL_COUNT);
 
   useEffect(() => {
     let countIgnore = false;

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -22,7 +22,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
 
     setInterval(() => {
       if (!countIgnore) {
-        setCount(count + 1);
+        setCount(count => count + 1);
       }
     }, 1000);
 

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -16,13 +16,12 @@ const INITIAL_COUNT = 0; // タイマーの初期値
 
 function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
   const [count, setCount] = useState(0);
-  const intervalRef: any = useRef(0);
 
   useEffect(() => {
-    let ignore = false;
+    let countIgnore = false;
 
-    intervalRef.current = setInterval(() => {
-      if (!ignore) {
+    setInterval(() => {
+      if (!countIgnore) {
         setCount(count + 1);
       }
     }, 1000);
@@ -32,7 +31,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
     }
 
     return () => {
-      ignore = true;
+      countIgnore = true;
     };
   }, [count, isOpen]);
 

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -22,12 +22,8 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
       setCount(count => count + 1); // stateではなく更新用のキューを見るので、依存配列にcountがなくても動く？
     }, 1000);
 
-    if (!isOpen) {
-      setCount(INITIAL_COUNT);
-      clearInterval(intervalId);
-    }
-
     return () => {
+      setCount(INITIAL_COUNT);
       clearInterval(intervalId);
     };
   }, [isOpen]);

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -16,7 +16,6 @@ const INITIAL_COUNT = 0; // タイマーの初期値
 
 function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
   const [count, setCount] = useState(0);
-
   const intervalRef: any = useRef(0);
 
   useEffect(() => {
@@ -31,7 +30,6 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
     if (!isOpen) {
       setCount(INITIAL_COUNT);
     }
-    console.log(intervalRef);
 
     return () => {
       ignore = true;

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   Button,
   Modal,
@@ -12,13 +12,32 @@ import {
   Center,
 } from "@chakra-ui/react";
 
+const INITIAL_COUNT = 0; // タイマーの初期値
+
 function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
   const [count, setCount] = useState(0);
+
+  const intervalRef: any = useRef(0);
+
   useEffect(() => {
-    setInterval(() => {
-      setCount(count + 1);
+    let ignore = false;
+
+    intervalRef.current = setInterval(() => {
+      if (!ignore) {
+        setCount(count + 1);
+      }
     }, 1000);
-  }, []);
+
+    if (!isOpen) {
+      setCount(INITIAL_COUNT);
+    }
+    console.log(intervalRef);
+
+    return () => {
+      ignore = true;
+    };
+  }, [count, isOpen]);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -18,12 +18,8 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
   const [count, setCount] = useState(INITIAL_COUNT);
 
   useEffect(() => {
-    let countIgnore = false;
-
-    let intervalId = setInterval(() => {
-      if (!countIgnore) {
-        setCount(count => count + 1);
-      }
+    const intervalId = setInterval(() => {
+      setCount(count => count + 1);
     }, 1000);
 
     if (!isOpen) {
@@ -31,7 +27,6 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
     }
 
     return () => {
-      countIgnore = true;
       clearInterval(intervalId);
     };
   }, [count, isOpen]);

--- a/src/ExerciseComponents/Question1/Question1.tsx
+++ b/src/ExerciseComponents/Question1/Question1.tsx
@@ -19,7 +19,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setCount(count => count + 1);
+      setCount(count => count + 1); // stateではなく更新用のキューを見るので、依存配列にcountがなくても動く？
     }, 1000);
 
     if (!isOpen) {
@@ -30,7 +30,7 @@ function TimerModal({ isOpen, onClose }: { isOpen: any; onClose: any }) {
     return () => {
       clearInterval(intervalId);
     };
-  }, [count, isOpen]);
+  }, [isOpen]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
# 概要
https://github.com/daiki-shiroma/react-practice/assets/94623074/be1a56c8-a955-43ca-b75c-db5762ac17ea

# 改善箇所
- useEffect内に依存関係を追加した
   - modalの内容がcountとisOpenの更新で変化するため

- クリーンアップ関数を追加した
   - countIgnoreがないと、前のアンマウント時の0が画面に描画されて一瞬カウントがカクツクから


# 見てほしい箇所
`const intervalRef: any = useRef(0);`
は大丈夫か？ ❌

↑そもそも要らなかった。
modalを閉じて開いたときに、カウントを再開すると勘違いしていて、その時の名残が残っていた。